### PR TITLE
Update create.jinja2

### DIFF
--- a/templates/create.jinja2
+++ b/templates/create.jinja2
@@ -5,7 +5,7 @@
 {% block content %}
 <form method="POST">
     <label for="name-input">Donor Name:</label><input id="name-input" type="text" name="name">
-    <label for="donation-input">Donation:</label><input id="donation-input" type="int" name="donation">
+    <label for="donation-input">Donation:</label><input id="donation-input" type="number" name="donation">
     <input type="submit" value="Add Donor">
 </form>
 {% endblock content %}


### PR DESCRIPTION
Good thought process here about how the type of a form input might relate to the Python type that you're going to want to use for the variable.

Unfortunately, HTML forms and Python aren't able to communicate this closely with each other. The closest we can do is `type=number`.